### PR TITLE
Bugfix: Do not overwrite 200 response

### DIFF
--- a/Extraction/Extractor/PhpDocOperationExtractor.php
+++ b/Extraction/Extractor/PhpDocOperationExtractor.php
@@ -73,6 +73,9 @@ class PhpDocOperationExtractor implements ExtractorInterface
         }
 
         foreach ($docBlock->getTagsByName('return') as $returnTag) {
+            if ($operation->responses[200] instanceof Response) {
+                continue;
+            }
             /* @var $returnTag \phpDocumentor\Reflection\DocBlock\Tags\Return_ */
             $response = new Response();
             $response->schema = $responseSchema = new Schema();


### PR DESCRIPTION
In the PhpDoc extractor a former generated 200 response was overwritten before.